### PR TITLE
Added zos fix

### DIFF
--- a/ocean_emulators/postprocessing.py
+++ b/ocean_emulators/postprocessing.py
@@ -33,7 +33,7 @@ def post_processor(ds: xr.Dataset, ds_truth: xr.Dataset) -> xr.Dataset:
 
     ds_out = xr.Dataset(variables)
     for var in ds_out.data_vars:
-        if 'lev' in ds_out[var].dims:
+        if "lev" in ds_out[var].dims:
             ds_out[var] = ds_out[var].where(ds_truth.wetmask)
         else:
             ds_out[var] = ds_out[var].where(ds_truth.wetmask.isel(lev=0))

--- a/ocean_emulators/postprocessing.py
+++ b/ocean_emulators/postprocessing.py
@@ -32,8 +32,11 @@ def post_processor(ds: xr.Dataset, ds_truth: xr.Dataset) -> xr.Dataset:
     variables["zos"] = da.isel(var=-1).squeeze()
 
     ds_out = xr.Dataset(variables)
-
-    ds_out = ds_out.where(ds_truth.wetmask)
+    for var in ds_out.data_vars:
+        if 'lev' in ds_out[var].dims:
+            ds_out[var] = ds_out[var].where(ds_truth.wetmask)
+        else:
+            ds_out[var] = ds_out[var].where(ds_truth.wetmask.isel(lev=0))
 
     ## attach all coordinates from input
     ds_out = ds_out.assign_coords({co: ds_truth[co] for co in ds_truth.coords})

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -9,7 +9,7 @@ def test_post_processor(input_data, raw_prediction):
     ds = post_processor(ds_raw, ds_input)
     assert set(ds.data_vars) == set(["so", "thetao", "zos", "uo", "vo"])
     assert ds.sizes == {"time": 3, "x": 360, "y": 180, "lev": 19}
-    assert set(['x','y','time']) == set(ds['zos'].dims)
+    assert set(["x", "y", "time"]) == set(ds["zos"].dims)
     for co in ds.coords:
         xr.testing.assert_equal(ds[co], ds_input[co])
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -9,6 +9,7 @@ def test_post_processor(input_data, raw_prediction):
     ds = post_processor(ds_raw, ds_input)
     assert set(ds.data_vars) == set(["so", "thetao", "zos", "uo", "vo"])
     assert ds.sizes == {"time": 3, "x": 360, "y": 180, "lev": 19}
+    assert set(['x','y','time']) == set(ds['zos'].dims)
     for co in ds.coords:
         xr.testing.assert_equal(ds[co], ds_input[co])
 


### PR DESCRIPTION
Fixing the issue in the postprocessor function in line `ds_out = ds_out.where(ds_truth.wetmask)` which broadcasts the zos variables across the wet mask levels creating an additional level dimension.